### PR TITLE
Add random delay between actions

### DIFF
--- a/src/like.ts
+++ b/src/like.ts
@@ -38,6 +38,12 @@ async function saveScreenshot(page: Page, name: string): Promise<void> {
   console.log(`スクリーンショット保存: ${filePath}`);
 }
 
+// 指定した範囲でランダムな待機を行う
+async function waitRandom(minMs = 15000, maxMs = 45000): Promise<void> {
+  const delay = Math.floor(Math.random() * (maxMs - minMs + 1)) + minMs;
+  return new Promise((resolve) => setTimeout(resolve, delay));
+}
+
 const clickButtonByText = async (page: Page, text: string) => {
   return await page.evaluate((targetText) => {
     const elements = Array.from(document.querySelectorAll('button'));
@@ -274,13 +280,13 @@ async function main() {
         // console.log('いいね！ボタンをクリックしました。');
         // return true;
 
-        await new Promise((resolve) => setTimeout(resolve, 2000));
+        await waitRandom();
       } catch (error) {
         console.log('いいねボタンが見つかりません:', error);
       }
 
       // 次のページに移動する前に少し待機
-      await new Promise((resolve) => setTimeout(resolve, 2000));
+      await waitRandom();
     }
   } catch (error) {
     console.error('エラーが発生しました:', error);


### PR DESCRIPTION
## Summary
- implement `waitRandom` helper for variable delays
- use `waitRandom` after each like to mimic human behavior

## Testing
- `npm run lint`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68423ff7162c8325a07f130ef198dcf7