### PR TITLE
Implement like limit config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,8 @@ HEADLESS=false
 
 # スクリーンショット保存ディレクトリ
 SCREENSHOT_DIR=./screenshots
+# 1回の処理で実行するいいねの上限
+LIKE_LIMIT=30
 
 # Insta ID/Pass
 INSTA_ID=

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 1. Node.js 20.x 以上をインストールしてください。
 2. プロジェクトルートで `npm install` を実行し、依存パッケージをインストールします。
 3. `.env.example` を `.env` にコピーし、必要な値（Instagram の ID やパスワードなど）を設定します。
+   `LIKE_LIMIT` を変更することで、1回の実行で行う「いいね」の件数を調整できます。
 
 # データ準備
 APPIFYのInstagramでjson形式で出力

--- a/src/like.ts
+++ b/src/like.ts
@@ -14,6 +14,7 @@ interface Config {
   checkInterval: number; // ミリ秒
   headless: boolean;
   screenshotDir: string;
+  likeLimit: number;
 }
 
 const config: Config = {
@@ -23,6 +24,7 @@ const config: Config = {
   checkInterval: parseInt(process.env.CHECK_INTERVAL || '5000'), // デフォルト5秒
   headless: process.env.HEADLESS !== 'false', // デフォルトはheadlessモード
   screenshotDir: process.env.SCREENSHOT_DIR || './screenshots',
+  likeLimit: parseInt(process.env.LIKE_LIMIT || '30'),
 };
 
 // スクリーンショット用ディレクトリの作成
@@ -198,7 +200,13 @@ async function main() {
       return;
     }
 
+    let likeCount = 0;
+
     for (const url of urls) {
+      if (likeCount >= config.likeLimit) {
+        console.log(`いいね上限 (${config.likeLimit}) に達したため処理を終了します`);
+        break;
+      }
       console.log(`処理中: ${url}`);
       await page.goto(url, { waitUntil: 'networkidle2' });
 
@@ -253,6 +261,7 @@ async function main() {
         });
 
         await buttonElement.tap();
+        likeCount++;
 
         await waitRandom();
       } catch (error) {


### PR DESCRIPTION
## Summary
- configure the max number of likes in a single run
- document LIKE_LIMIT in README and env example

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6842425126508325beb663c59ee19ce7