### PR TITLE
Handle already followed state

### DIFF
--- a/src/like.ts
+++ b/src/like.ts
@@ -117,6 +117,10 @@ const clickFollowButton = async (page: Page): Promise<boolean> => {
       await btn.tap();
       return true;
     }
+    // 既にフォロー済みの場合
+    if (text.includes('フォロー中') || text.includes('メッセージ')) {
+      return false;
+    }
   }
   return false;
 };
@@ -233,6 +237,8 @@ async function main() {
         if (followed) {
           console.log('フォローしました');
           await waitRandom();
+        } else {
+          console.log('既にフォロー済みのためスキップ');
         }
       } catch (error) {
         console.log('フォローボタンが見つかりません:', error);


### PR DESCRIPTION
## Summary
- handle existing follow state in `clickFollowButton`
- log message when user is already followed

## Testing
- `npm run lint`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684cd31f0fa08325ac2f7e177061fbf4