### PR TITLE
Fix follow loop behavior

### DIFF
--- a/src/like.ts
+++ b/src/like.ts
@@ -119,7 +119,7 @@ const clickFollowButton = async (page: Page): Promise<boolean> => {
     }
     // 既にフォロー済みの場合
     if (text.includes('フォロー中') || text.includes('メッセージ')) {
-      return false;
+      break; // 既にフォローしているのでループを終了
     }
   }
   return false;
@@ -165,7 +165,7 @@ const isPostLiked = async (page: Page): Promise<boolean> => {
 };
 
 // メイン処理
-async function main() {
+async function main(): Promise<void> {
   const browser = await puppeteer.launch({
     headless: config.headless,
     defaultViewport: null,


### PR DESCRIPTION
## Summary
- stop returning false early when looking at follow buttons
- ensure `main` explicitly returns `Promise<void>`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684cd559f1c48325bb59caaf4e0fd5e7