### PR TITLE
Implement unified action log

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@
   npm run like
 ```
 
-実行が完了すると `like_log.csv` に以下の形式でログが追記されます。
+実行が完了すると `action_log.csv` に以下の形式でログが追記されます。
 
 ```
-post_url,like_date,owner_url
+date,action,url,owner_url
 ```
 
-`owner_url` には `data.json` の `ownerUsername` を用いたアカウントURLが記録されます。
+`owner_url` には `data.json` の `ownerUsername` を用いたアカウントURLが記録されます。`action` は `like`、`follow`、`comment` のいずれかです。


### PR DESCRIPTION
## Summary
- replace per-action logs with a single `action_log.csv`
- add helper utilities to write unified log
- compute daily counts from unified log
- update README to document new log format

## Testing
- `npm run build`
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684cd7a711b88325948939362fd96b66